### PR TITLE
Enable Firebase authentication via Spring Security

### DIFF
--- a/src/main/java/rs/aleksa/simpletoolmanager/config/SecurityConfig.java
+++ b/src/main/java/rs/aleksa/simpletoolmanager/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package rs.aleksa.simpletoolmanager.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import rs.aleksa.simpletoolmanager.security.FirebaseAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final FirebaseAuthenticationFilter firebaseFilter;
+
+    public SecurityConfig(@Autowired(required = false) @Nullable FirebaseAuthenticationFilter firebaseFilter) {
+        this.firebaseFilter = firebaseFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+        if (firebaseFilter != null) {
+            http.addFilterBefore(firebaseFilter, UsernamePasswordAuthenticationFilter.class);
+        }
+        return http.build();
+    }
+}

--- a/src/main/java/rs/aleksa/simpletoolmanager/security/FirebaseAuthenticationFilter.java
+++ b/src/main/java/rs/aleksa/simpletoolmanager/security/FirebaseAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package rs.aleksa.simpletoolmanager.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import rs.aleksa.simpletoolmanager.model.auth.AuthUser;
+import rs.aleksa.simpletoolmanager.service.AuthService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Filter that validates Firebase ID tokens from the Authorization header.
+ */
+@Component
+@ConditionalOnBean(AuthService.class)
+public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AuthService authService;
+
+    public FirebaseAuthenticationFilter(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                AuthUser user = authService.verifyIdToken(token);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        user,
+                        token,
+                        List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())));
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (RuntimeException ex) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## Summary
- add a request filter that validates Firebase ID tokens and populates the security context
- configure Spring Security to register the Firebase filter and require auth for requests

## Testing
- `mvn -q test` *(failed: Could not resolve parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf82665f408333b85e24ca31089501