### PR TITLE
Allow unauthenticated access when Firebase auth is disabled

### DIFF
--- a/src/main/java/rs/aleksa/simpletoolmanager/config/SecurityConfig.java
+++ b/src/main/java/rs/aleksa/simpletoolmanager/config/SecurityConfig.java
@@ -28,14 +28,18 @@ public class SecurityConfig {
             HttpSecurity http,
             @Autowired(required = false) @Nullable FirebaseAuthenticationFilter firebaseFilter
     ) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/**").permitAll()
-                        .anyRequest().authenticated()
-                );
+        http.csrf(AbstractHttpConfigurer::disable);
+
         if (firebaseFilter != null) {
+            http.authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/**").permitAll()
+                    .anyRequest().authenticated()
+            );
             http.addFilterBefore(firebaseFilter, UsernamePasswordAuthenticationFilter.class);
+        } else {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         }
+
         return http.build();
     }
 }


### PR DESCRIPTION
## Summary
- Conditionally permit all requests when Firebase authentication is not configured, preventing unintended 403 errors

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c05ae9bb2883339bb286e4c32f33f0