### PR TITLE
Return 401 for unauthorized

### DIFF
--- a/src/main/java/rs/aleksa/simpletoolmanager/config/SecurityConfig.java
+++ b/src/main/java/rs/aleksa/simpletoolmanager/config/SecurityConfig.java
@@ -8,7 +8,9 @@ import org.springframework.lang.Nullable;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import rs.aleksa.simpletoolmanager.security.FirebaseAuthenticationFilter;
 import rs.aleksa.simpletoolmanager.service.AuthService;
@@ -36,6 +38,9 @@ public class SecurityConfig {
                     .anyRequest().authenticated()
             );
             http.addFilterBefore(firebaseFilter, UsernamePasswordAuthenticationFilter.class);
+            http.exceptionHandling(ex ->
+                    ex.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+            );
         } else {
             http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         }


### PR DESCRIPTION
## Summary
- Return HTTP 401 for unauthenticated requests by adding HttpStatusEntryPoint to SecurityConfig

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c05d7800688333aa217a255650e300